### PR TITLE
[WIP] Accesseurs et descripteurs

### DIFF
--- a/src/7-accessors-descriptors/1-accessors.md
+++ b/src/7-accessors-descriptors/1-accessors.md
@@ -3,9 +3,9 @@
 Que font réellement `getattr`, `setattr` et `delattr` ? Elles appellent des méthodes spéciales de l'objet.
 
 `setattr` et `delattr` sont les cas les plus simples, la correspondance est faite avec les méthodes `__setattr__` et `__delattr__`.
-Ces deux méthodes prennent respectivement les mêmes paramètres (en plus de `self`) que les fonctions auxquelles elles correspondent. `__setattr__` prendra donc le nom de l'attribut et sa nouvelle valeur, et `__delattr__` le nom de l'attribut.
+Ces deux méthodes prennent les mêmes paramètres (en plus de `self`) que les fonctions auxquelles elles correspondent. `__setattr__` prendra donc le nom de l'attribut et sa nouvelle valeur, et `__delattr__` le nom de l'attribut.
 
-Quant à `getattr`, la chose est un pleu complexe, car deux méthodes spéciales lui correspondent : `__getattribute__` et `__getattr__`. Ces deux méthodes prennent en paramètre le nom de l'attribut.
+Quant à `getattr`, la chose est un peu plus complexe, car deux méthodes spéciales lui correspondent : `__getattribute__` et `__getattr__`. Ces deux méthodes prennent en paramètre le nom de l'attribut.
 La première est appelée lors de la récupération de tout attribut. La seconde est réservée aux cas où l'attribut n'a pas été trouvé (si `__getattribute__` lève une `AttributeError`).
 
 Ces méthodes sont chargées de retourner la valeur de l'attribut demandé.
@@ -69,7 +69,7 @@ Je vous invite à consulter la section de la documentation consacrée aux slots 
 
 ### MRO
 
-J'évoquais précédemment le comportement de `__getattribute__`, qui consiste à consulter le dictionnaire de l'objet puis de ces parents. Ce mécanisme est appelé *method resolution order* ou plus généralement *MRO*.
+J'évoquais précédemment le comportement de `__getattribute__`, qui consiste à consulter le dictionnaire de l'objet puis de ses parents. Ce mécanisme est appelé *method resolution order* ou plus généralement *MRO*.
 
 Chaque classe que vous définissez possède une méthode `mro`. Elle retourne un *tuple* contenant l'ordre des classes à interroger lors de la résolution d'un appel sur l'objet.
 C'est ce *MRO* qui définit la priorité des classes parentes lors d'un héritage multiple (quelle classe interroger en priorité), c'est encore lui qui est utilisé lors d'un appel à `super`, afin de savoir à quelle classe `super` fait référence.

--- a/src/7-accessors-descriptors/5-tp.md
+++ b/src/7-accessors-descriptors/5-tp.md
@@ -1,10 +1,10 @@
 ## TP : propriétés et méthodes
 
-Pour clore ce chapitre, je vous propose d'implémenter les descripteurs `staticmethod` et `classmethod`. J'ajouterais à cela un descripteur `method` qui reproduirait le comportement par défaut des méthodes en Python.
+Pour clore ce chapitre, je vous propose d'implémenter les descripteurs `staticmethod` et `classmethod`. J'ajouterai à cela un descripteur `method` qui reproduirait le comportement par défaut des méthodes en Python.
 
 Pour résumer :
 
-* Ces 3 descripteurs sont de type *non-data* (n'implémentent que `__get__`) ;
+* Ces trois descripteurs sont de type *non-data* (n'implémentent que `__get__`) ;
 * `my_staticmethod`
     * Retourne la fonction cible, qu'elle soit utilisée depuis la classe ou depuis l'instance ;
 * `my_classmethod`


### PR DESCRIPTION
En cours. Remarques restantes à prendre en compte : 
# L'attribut de Dana

> Il est en cela possible d'implémenter des attributs dynamiquement, en modifiant le comportement des méthodes : par exemple une condition sur le nom de l'attribut pour retourner une valeur particulière.

Un exemple de code pourrait aider, j'ai un peu bloqué là-dessus. En effet, on peut déjà créer des attributs dynamiquement sans modifier ces méthodes (`foo.bar = x` fonctionne, que `foo.bar` existe ou non). Mais j'imagine que par "condition sur le nom de l'attribut", tu entends un truc plus complexe que `if attr == "bar":`, du genre `if "bar" in attr:`.

> `raise AttributeError(name)`

Tu pourrais ajouter un commentaire dans le code pour dire qu'ici, comme on hérite directement d'`object`, qui n'a pas de méthode `__getattr__`, on lève une exception.

>  le **dict** n'aura plus besoin d'être instancié lors de la création d'un nouvel objet

Effectivement, `__dict__` n'existe pas. Mais du coup, c'est un peu chiant pour récupérer les attributs d'un objet, puisqu'il faut regarder si l'un existe, sinon l'autre. Ils ne font pas `__dict__ = __slots__` pour que le programmeur sache qu'il ne pourra "plus par défaut définir d'attributs autres sur l'objet que ceux décrits dans les slots" ?

> afin de savoir à quelle classe super fait référence

`super()` plutôt que `super` ?

> On recherche dans foo.**dict** la présence d'une clef 'bar', dont on retourne la valeur si la clef existe

Et dans `foo.__slots__` ?

---

J'ai eu un peu de mal avec cette histoire d'attributs dynamiques. A voir, mais il me semble plus clair de mettre le code avant, qu'on ait un exemple sous les yeux. Le code irait juste après le paragraphe : 

> Ces méthodes sont chargées de retourner la valeur de l'attribut demandé. Il est en cela possible d'implémenter des attributs dynamiquement, en modifiant le comportement des méthodes : par exemple une condition sur le nom de l'attribut pour retourner une valeur particulière.
# Les descripteurs

> Cependant, seul l'accès en lecture sera possible sur la classe, les opérations de modification et de suppression servant à remplacer ou supprimer le descripteur.

Je ne suis pas sûr de comprendre cela.

> ``` python
> # Dans le cas où on appellerait `Temperature.celsius`
> # On préfère retourner le descripteur lui-même
> ```

Je ne comprends pas pourquoi on fait cela. Probablement lié à la remarque précédente.
# Les propriétés

> `class my_property:`

Pourquoi pas `MyProperty` ?

> `@celsius.setter`

Je ne sais pas pourquoi, mais j'ai bloqué sur cette ligne. Peut-être indiquer en commentaire `# Identique à @(property(celsius).setter)` ?
# Les méthodes

> En fait, les méthodes sont des descripteurs vers les fonctions que vous définissez à l'intérieur de votre classe.

Il me semble intéressant de donner un exemple de code d'un tel descripteur, voire des trois (méthodes normales, de classe et statiques).

Ah ben en fait c'est le TP.
# TP : propriétés et méthodes

> Notez que vous pouvez vous aider du type MethodType (from types import MethodType) pour créer vos bound methods.

Je ne suis pas sûr de comprendre à quoi ça sert. Est-ce équivalent au code ci-dessous ?

``` python
def method_type(func, first):
    def f(*args, **kwargs):
        return func(first, *args, **kwargs)
    return f
```

Le cas échéant, pourquoi ont-ils utilisé une classe ?

Il ne me semble pas déconnant d'intégrer au TP la fonction ci-dessus, de sorte que le lecteur comprenne bien cette histoire de préparation de fonction.

> `class my_staticmethod:`

Même remarque/question que plus haut sur le nommage.
